### PR TITLE
Fix: Update frontend port mapping to 8000

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
   frontend:
     build: ./frontend
     ports:
-      - "3001:80"
+      - "8000:80"
     depends_on:
       backend:
         condition: service_healthy


### PR DESCRIPTION
## Summary
Fixed 502 Bad Gateway errors by updating the frontend port mapping from 3001 to 8000 in docker-compose.yml.

## Problem
- Frontend was exposed on port 3001 but application was trying to access port 8000
- This caused 502 Bad Gateway errors for all API requests
- Error: \POST http://140.245.219.152:8000/api/admin/login 502 (Bad Gateway)\

## Solution
Updated \docker-compose.yml\ to map frontend service to port 8000 instead of 3001.

## Changes
- Modified \docker-compose.yml\: Changed frontend port mapping from \3001:80\ to \8000:80\

## Testing
After deployment:
\\\ash
docker-compose down
docker-compose build frontend
docker-compose up -d
\\\

Verify:
- Frontend loads at http://140.245.219.152:8000
- API requests to \/api/*\ return expected responses
- No 502 errors

## Checklist
- [x] Follows project conventions
- [x] No security vulnerabilities
- [x] Production-ready
- [x] Minimal change scope