### PR TITLE
fix: resolve docker port conflicts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,8 @@ services:
 
   backend:
     build: ./backend
-    ports:
-      - "5000:5000"
+    expose:
+      - "5000"
     env_file:
       - ./backend/.env
     depends_on:
@@ -31,8 +31,8 @@ services:
 
   frontend:
     build: ./frontend
-    ports:
-      - "8000:80"
+    expose:
+      - "80"
     depends_on:
       backend:
         condition: service_healthy


### PR DESCRIPTION
## Problem

Production deployment showed port conflicts:
- Backend port 5001 conflicting with external services
- Frontend port 8000 conflicting with nginx
- Services exposed unnecessarily to host network

## Solution

Changed ports to expose for backend and frontend services:
- Backend: expose: [5000] (was ports: [5001:5000])
- Frontend: expose: [80] (was ports: [8000:80])

## Benefits

- No port conflicts with external services
- Nginx remains sole entry point (8000, 8443)
- Backend/frontend only accessible within Docker network
- Improved security posture

## Testing

Verified on production server:
- Nginx accessible on ports 8000 (HTTP) and 8443 (HTTPS)
- Backend/frontend communicate internally
- No port conflicts

## Deployment

docker-compose down && docker-compose up -d

Access via: http://server:8000 or https://server:8443