### PR TITLE
Fix backend health check - add curl and non-blocking Redis

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:20-alpine
 
-RUN apk add --no-cache openssl
+RUN apk add --no-cache openssl curl
 
 WORKDIR /app
 

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -13,9 +13,11 @@ import reviewRoutes from './routes/review.routes.js';
 import orderRoutes from './routes/order.routes.js';
 import messageRoutes from './routes/message.routes.js';
 
-await initRedis();
-
 const app = express();
+
+initRedis().catch((err) => {
+  logger.error('Redis initialization failed, continuing without cache', err);
+});
 
 app.set('etag', false);
 app.use(

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -70,18 +70,17 @@ services:
       REDIS_TTL: 3600
       NODE_OPTIONS: --max-old-space-size=256
     depends_on:
-      postgres:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
+      - postgres
+      - redis
     restart: unless-stopped
     mem_limit: 384m
     mem_reservation: 256m
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:5000/api/health || exit 1"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     networks:
       - internal
     logging:


### PR DESCRIPTION
## Problem
- Backend container marked as unhealthy
- Health check failing because curl not installed in alpine image
- Redis initialization blocking server startup

## Solution
1. Added curl to backend Dockerfile
2. Changed Redis init from blocking await to non-blocking with error handling
3. Adjusted health check timing (15s interval, 30s start period)

## Changes
- backend/Dockerfile: Added curl package
- backend/src/server.js: Non-blocking Redis initialization
- docker-compose.prod.yml: Removed strict health dependencies, adjusted timing