### PR TITLE
Fix for Useless conditional

### DIFF
--- a/backend/src/utils/cacheHelper.js
+++ b/backend/src/utils/cacheHelper.js
@@ -3,7 +3,7 @@ import config from '../config/index.js';
 import logger from './logger.js';
 
 export const getCached = async (key) => {
-  if (!config.redisEnabled || !redisClient) return null;
+  if (!config.redisEnabled) return null;
 
   try {
     const cached = await redisClient.get(key);
@@ -15,7 +15,7 @@ export const getCached = async (key) => {
 };
 
 export const setCached = async (key, value, ttl = config.redisTtl) => {
-  if (!config.redisEnabled || !redisClient) return;
+  if (!config.redisEnabled) return;
 
   try {
     await redisClient.setEx(key, ttl, JSON.stringify(value));
@@ -25,7 +25,7 @@ export const setCached = async (key, value, ttl = config.redisTtl) => {
 };
 
 export const deleteCached = async (key) => {
-  if (!config.redisEnabled || !redisClient) return;
+  if (!config.redisEnabled) return;
 
   try {
     await redisClient.del(key);
@@ -35,7 +35,7 @@ export const deleteCached = async (key) => {
 };
 
 export const clearPattern = async (pattern) => {
-  if (!config.redisEnabled || !redisClient) return;
+  if (!config.redisEnabled) return;
 
   try {
     const keys = await redisClient.keys(pattern);


### PR DESCRIPTION
In general, to fix a condition that includes a subexpression which always evaluates to the same boolean, you either remove the redundant part or restructure the check so that it meaningfully reflects possible runtime states. Here, CodeQL says `!redisClient` is constant, so `!config.redisEnabled || !redisClient` effectively collapses to a single check. The simplest and safest fix, without changing observable behavior in a typical “always-created client” design, is to make the intent explicit: guard all Redis operations solely on `config.redisEnabled`. This removes the logically dead `!redisClient` part and eliminates the “always true/false” warning.

Concretely, in `backend/src/utils/cacheHelper.js` we should update the early-return guards in all cache helper functions (`getCached`, `setCached`, `deleteCached`, `clearPattern`) to check only `!config.redisEnabled`. That means replacing `if (!config.redisEnabled || !redisClient) ...` with `if (!config.redisEnabled) ...` on lines 6, 18, 28, and 38. No new imports or additional logic are required, and functionality remains the same if `redisClient` is always a valid object in normal operation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._