### PR TITLE
Fix for Useless conditional

### DIFF
--- a/backend/src/middleware/cache.js
+++ b/backend/src/middleware/cache.js
@@ -23,9 +23,6 @@ export const cache = (ttl = config.redisTtl) => {
 
       res.sendResponse = res.json;
       res.json = async (body) => {
-        if (!redisClient) {
-          return res.sendResponse(body);
-        }
         await redisClient.setEx(key, ttl, JSON.stringify(body));
         res.sendResponse(body);
       };


### PR DESCRIPTION
In general, to fix a condition that always evaluates to the same value, remove or adjust the redundant condition so the remaining logic reflects actual possible runtime states. Here, by the time the code executes the custom `res.json` override, we already know `redisClient` is truthy due to the early guard on lines 7–9. Therefore the inner `if (!redisClient)` on line 26 can never be true and should be removed. The override should always perform the caching operation, and if Redis operations fail they are already covered by the outer try/catch.

Concretely, in `backend/src/middleware/cache.js`, within the `cache` middleware, update the `res.json` override at lines 24–31 to remove the redundant `if (!redisClient)` block. The function should unconditionally call `await redisClient.setEx(...)` and then call `res.sendResponse(body)`. No new imports or helpers are required; this is a minimal change that preserves existing behavior while removing the always-false condition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._