### PR TITLE
[Security] Replace Math.random with crypto.randomInt for secure order IDs

### DIFF
--- a/backend/src/services/order.service.js
+++ b/backend/src/services/order.service.js
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import * as orderRepository from '../repositories/order.repository.js';
 import prisma from '../utils/prisma.js';
 import logger from '../utils/logger.js';
@@ -83,7 +84,7 @@ const validateOrderData = (data) => {
 };
 
 const generateOrderId = () => {
-  const randomNum = Math.floor(100000 + Math.random() * 900000);
+  const randomNum = crypto.randomInt(100000, 1000000);
   return `VV-${randomNum}`;
 };
 


### PR DESCRIPTION
## Summary
This PR replaces the insecure `Math.random()` with the cryptographically secure `crypto.randomInt()` for order ID generation in the backend.

## Related Issues
Fixes #71

## Changes
- Updated `backend/src/services/order.service.js` to use `crypto.randomInt` for 6-digit order ID generation.
- Added `import crypto from 'crypto'` at the top of the file.

## Testing Performed
- Verified that `generateOrderId` consistently produces 6-digit numeric strings with the `VV-` prefix.
- Confirmed that the new logic works correctly via a standalone verification script.
- Verified that no other instances of `Math.random()` are used for sensitive ID generation in the backend.
