### PR TITLE
[Security] Fix CSRF Vulnerability on Admin Token Refresh Endpoint

### DIFF
--- a/backend/src/utils/request.js
+++ b/backend/src/utils/request.js
@@ -11,7 +11,7 @@ export const getIpAddress = (req) => {
 const getCookieOptions = () => ({
   httpOnly: true,
   secure: config.nodeEnv === 'production',
-  sameSite: config.nodeEnv === 'production' ? 'none' : 'lax',
+  sameSite: 'strict',
   path: '/',
 });
 


### PR DESCRIPTION
## Summary of changes
Changed `sameSite` configuration for cookies from `none` to `strict` in production to prevent Cross-Site Request Forgery (CSRF) vulnerabilities on the `/api/admin/refresh` endpoint. This ensures cookies are only sent in a first-party context, aligning with the security guidelines in claude.md.

## Related issue numbers
Fixes #63

## Testing performed
Verified that the Prettier formatting checks passed on the backend codebase. No UI changes were made.

## Screenshots (if UI changes)
N/A
