### PR TITLE
fix: incorrect destructuring of redisClient.scan result

### DIFF
--- a/backend/src/middleware/cache.js
+++ b/backend/src/middleware/cache.js
@@ -51,10 +51,13 @@ export const clearCache = async (pattern = '*') => {
 
     do {
       // Use SCAN to iterate over keys matching the cache pattern in a non-blocking way
-      const [nextCursor, foundKeys] = await redisClient.scan(cursor, {
-        MATCH: matchPattern,
-        COUNT: 100,
-      });
+      const { cursor: nextCursor, keys: foundKeys } = await redisClient.scan(
+        cursor,
+        {
+          MATCH: matchPattern,
+          COUNT: 100,
+        }
+      );
 
       cursor = Number(nextCursor);
 


### PR DESCRIPTION
### Summary of Changes
Fixed a bug in the `clearCache` function where the `redisClient.scan` result was incorrectly destructured as an array. Since `node-redis` v4 returns an object with `cursor` and `keys` properties, this caused cache invalidation to fail with a `TypeError: redisClient.scan(...) is not iterable`. The destructuring has been updated to use the object syntax `{ cursor, keys }`.

### Related Issue
Fixes #64

### Testing Performed
- Verified that the `redisClient.scan` object destructuring correctly extracts `cursor` and `keys`.
- Ran `npm run format` and `npm run format:check` to ensure code style compliance.
- No UI changes, so no screenshots.
