### PR TITLE
fix(admin): surface real login error instead of generic message

### DIFF
--- a/frontend/src/hooks/useAdminAuth.ts
+++ b/frontend/src/hooks/useAdminAuth.ts
@@ -26,8 +26,13 @@ export const useAdminAuth = () => {
       });
 
       navigate("/sys-admin-dashboard");
-    } catch {
-      const errorMessage = "Login failed";
+    } catch (err) {
+      const errorMessage =
+        err instanceof TypeError
+          ? "Cannot reach server. Check your connection or try again."
+          : err instanceof Error && err.message
+            ? err.message
+            : "Login failed";
       setError(errorMessage);
 
       toast({


### PR DESCRIPTION
## Summary
- Login error handler used `catch {}` and always toasted "Login failed", hiding real causes (CORS rejection, invalid credentials, 5xx)
- Now surfaces the API's `message` from `loginAdmin`, distinguishes fetch `TypeError` (network/CORS) with a clearer hint, and falls back to the generic text only when nothing is available

## Why this matters
A production CORS misconfiguration today caused login to fail silently for an admin — the browser saw "Login failed" with no clue that the server was actually rejecting the origin. With this change the toast would have shown the network hint and saved a debug round-trip.

## Test plan
- [ ] Bad credentials show the API's "Invalid credentials" message
- [ ] Network failure / CORS rejection shows the network hint
- [ ] Successful login still navigates to /sys-admin-dashboard

Generated with assistance from Claude Code